### PR TITLE
docs: enforce PR and issue linking in gitflow

### DIFF
--- a/project-context.md
+++ b/project-context.md
@@ -17,7 +17,7 @@ All BMad agents MUST strictly adhere to the Gitflow workflow when implementing s
   2. The branch naming convention is: `feature/story-[number]-[brief-name]` or `fix/issue-[number]`.
      *(Example: `git checkout -b feature/story-1.2-card-rendering develop`)*
   3. Work is performed and committed on this feature branch.
-  4. (Optional) Create a Pull Request to merge back into `develop` when the story is complete.
+  4. (MANDATORY) At the end of the dev and test pipeline, you must push your branch and open a Merge Request (Pull Request) on GitHub targeting `develop`. You MUST link the corresponding GitHub Issue in the MR description (e.g. by adding "Resolves #X") to track progress.
 
 ### 2. Semantic Versioning (SemVer) & Conventional Commits
 - The project strictly follows Semantic Versioning for releases.


### PR DESCRIPTION
Update GitFlow rules to make PRs and issue linking mandatory at the end of the dev pipeline.